### PR TITLE
Add animated login page and auth gating

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,13 +9,13 @@ import {
 } from '@mui/icons-material';
 
 import ServerDown from "./pages/ServerDown";
-
 import DashboardPage from './pages/DashboardPage';
 import PetTypes from './pages/PetTypes';
 import Breeds from './pages/Breeds';
 import Colors from './pages/Colors';
 import PetFoods from './pages/PetFoods';
 import UserTypes from './pages/UserTypes';
+import Login from './pages/Login';
 
 const drawerWidth = 220;
 
@@ -151,19 +151,33 @@ function Layout({ children }) {
 }
 
 export default function App() {
+  const [token, setToken] = React.useState(() => localStorage.getItem('token'));
+
+  const handleLogin = (tok) => {
+    localStorage.setItem('token', tok);
+    setToken(tok);
+  };
+
   return (
     <BrowserRouter>
-      <Layout>
+      {!token ? (
         <Routes>
-          <Route path="/" element={<DashboardPage />} />
-          <Route path="/pet-types" element={<PetTypes />} />
-          <Route path="/breeds" element={<Breeds />} />
-          <Route path="/colors" element={<Colors />} />
-          <Route path="/pet-foods" element={<PetFoods />} />
-          <Route path="/user-types" element={<UserTypes />} />
           <Route path="/server-down" element={<ServerDown />} />
+          <Route path="*" element={<Login onLogin={handleLogin} />} />
         </Routes>
-      </Layout>
+      ) : (
+        <Layout>
+          <Routes>
+            <Route path="/" element={<DashboardPage />} />
+            <Route path="/pet-types" element={<PetTypes />} />
+            <Route path="/breeds" element={<Breeds />} />
+            <Route path="/colors" element={<Colors />} />
+            <Route path="/pet-foods" element={<PetFoods />} />
+            <Route path="/user-types" element={<UserTypes />} />
+            <Route path="/server-down" element={<ServerDown />} />
+          </Routes>
+        </Layout>
+      )}
     </BrowserRouter>
   );
 }

--- a/src/api.js
+++ b/src/api.js
@@ -9,6 +9,15 @@ export const api = axios.create({
   baseURL: `${API_BASE_URL}`
 });
 
+// Attach stored JWT token to every request
+api.interceptors.request.use((config) => {
+  const token = localStorage.getItem('token');
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
 // Optional: global GET failure redirect (disabled if using homepage check instead)
 // let isServerCheckInProgress = false;
 // api.interceptors.response.use(

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,0 +1,120 @@
+import React, { useState } from 'react';
+import {
+  Box,
+  TextField,
+  Button,
+  Typography,
+  Paper,
+  CircularProgress,
+  Grow
+} from '@mui/material';
+import PetsIcon from '@mui/icons-material/Pets';
+import { api } from '../api';
+import { useNavigate } from 'react-router-dom';
+
+const gold = '#ae8625';
+const brown = '#7a5c27';
+const offWhite = '#fffbe6';
+
+export default function Login({ onLogin }) {
+  const navigate = useNavigate();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [errors, setErrors] = useState({});
+  const [loading, setLoading] = useState(false);
+  const [serverError, setServerError] = useState('');
+
+  const validate = () => {
+    const errs = {};
+    if (!email) errs.email = 'Email is required';
+    else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) errs.email = 'Invalid email address';
+    if (!password) errs.password = 'Password is required';
+    setErrors(errs);
+    return Object.keys(errs).length === 0;
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!validate()) return;
+    setLoading(true);
+    setServerError('');
+    try {
+      const res = await api.post('login', { email, password });
+      const token = res.data?.data?.token || res.data?.token;
+      if (token) {
+        onLogin(token);
+        navigate('/');
+      } else {
+        setServerError('Unexpected response from server');
+      }
+    } catch (err) {
+      const msg = err?.response?.data?.message || 'Login failed';
+      setServerError(msg);
+    }
+    setLoading(false);
+  };
+
+  return (
+    <Box
+      sx={{
+        minHeight: '100vh',
+        bgcolor: offWhite,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        p: 2
+      }}
+    >
+      <Grow in timeout={600}>
+        <Paper elevation={6} sx={{ p: 4, maxWidth: 400, width: '100%', borderRadius: 3 }}>
+          <Box sx={{ textAlign: 'center', mb: 3 }}>
+            <PetsIcon sx={{ fontSize: 40, color: gold }} />
+            <Typography variant="h5" sx={{ mt: 1, fontWeight: 700, color: brown }}>
+              Admin Login
+            </Typography>
+          </Box>
+          <Box component="form" onSubmit={handleSubmit}>
+            <TextField
+              label="Email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              fullWidth
+              sx={{ mb: 2 }}
+              error={Boolean(errors.email)}
+              helperText={errors.email}
+            />
+            <TextField
+              label="Password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              fullWidth
+              sx={{ mb: 2 }}
+              error={Boolean(errors.password)}
+              helperText={errors.password}
+            />
+            {serverError && (
+              <Typography color="error" sx={{ mb: 2 }}>
+                {serverError}
+              </Typography>
+            )}
+            <Button
+              type="submit"
+              variant="contained"
+              fullWidth
+              disabled={loading}
+              sx={{
+                bgcolor: gold,
+                color: '#fff',
+                fontWeight: 700,
+                '&:hover': { bgcolor: brown }
+              }}
+            >
+              {loading ? <CircularProgress size={24} /> : 'Login'}
+            </Button>
+          </Box>
+        </Paper>
+      </Grow>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- add responsive login page with form validation and subtle Grow animation
- gate dashboard routes behind login token and persist token to localStorage
- attach stored JWT to every axios request via interceptor

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689743c8df94832bbee7929633ada852