### PR TITLE
Add logout button and auth redirects

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { BrowserRouter, Routes, Route, Link, useLocation } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, Link, useLocation, useNavigate } from 'react-router-dom';
 import {
   CssBaseline, Box, Drawer, AppBar, Toolbar, Typography, IconButton, List,
-  ListItem, ListItemIcon, ListItemText, Divider, useTheme, useMediaQuery
+  ListItem, ListItemIcon, ListItemText, Divider, useTheme, useMediaQuery, Button
 } from '@mui/material';
 import {
   Pets, Category, Palette, Group, Fastfood, Menu as MenuIcon, Dashboard
@@ -28,11 +28,12 @@ const navItems = [
   { label: 'User Types', path: '/user-types', icon: <Group /> },
 ];
 
-function Layout({ children }) {
+function Layout({ children, onLogout }) {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const [mobileOpen, setMobileOpen] = React.useState(false);
   const location = useLocation();
+  const navigate = useNavigate();
 
   const drawer = (
     <div>
@@ -95,6 +96,17 @@ function Layout({ children }) {
           <Typography variant="h6" color="#fff" noWrap component="div">
             Admin Panel
           </Typography>
+          <Box sx={{ flexGrow: 1 }} />
+          <Button
+            color="inherit"
+            onClick={() => {
+              onLogout();
+              navigate('/');
+            }}
+            sx={{ textTransform: 'none' }}
+          >
+            Logout
+          </Button>
         </Toolbar>
       </AppBar>
 
@@ -158,6 +170,11 @@ export default function App() {
     setToken(tok);
   };
 
+  const handleLogout = () => {
+    localStorage.removeItem('token');
+    setToken(null);
+  };
+
   return (
     <BrowserRouter>
       {!token ? (
@@ -166,7 +183,7 @@ export default function App() {
           <Route path="*" element={<Login onLogin={handleLogin} />} />
         </Routes>
       ) : (
-        <Layout>
+        <Layout onLogout={handleLogout}>
           <Routes>
             <Route path="/" element={<DashboardPage />} />
             <Route path="/pet-types" element={<PetTypes />} />

--- a/src/api.js
+++ b/src/api.js
@@ -18,6 +18,21 @@ api.interceptors.request.use((config) => {
   return config;
 });
 
+// Redirect to login on unauthorized responses
+api.interceptors.response.use(
+  response => response,
+  error => {
+    if (error.response?.status === 401 && !error.config?.url?.includes('login')) {
+      const currentPath = window.location.pathname + window.location.search;
+      localStorage.removeItem('token');
+      localStorage.setItem('redirectAfterLogin', currentPath);
+      localStorage.setItem('authMessage', 'You are not logged in');
+      window.location.href = currentPath;
+    }
+    return Promise.reject(error);
+  }
+);
+
 // Optional: global GET failure redirect (disabled if using homepage check instead)
 // let isServerCheckInProgress = false;
 // api.interceptors.response.use(

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   Box,
   TextField,
@@ -23,6 +23,15 @@ export default function Login({ onLogin }) {
   const [errors, setErrors] = useState({});
   const [loading, setLoading] = useState(false);
   const [serverError, setServerError] = useState('');
+  const [infoMessage, setInfoMessage] = useState('');
+
+  useEffect(() => {
+    const msg = localStorage.getItem('authMessage');
+    if (msg) {
+      setInfoMessage(msg);
+      localStorage.removeItem('authMessage');
+    }
+  }, []);
 
   const validate = () => {
     const errs = {};
@@ -43,7 +52,13 @@ export default function Login({ onLogin }) {
       const token = res.data?.data?.token || res.data?.token;
       if (token) {
         onLogin(token);
-        navigate('/');
+        const redirectPath = localStorage.getItem('redirectAfterLogin');
+        if (redirectPath) {
+          localStorage.removeItem('redirectAfterLogin');
+          navigate(redirectPath);
+        } else {
+          navigate('/');
+        }
       } else {
         setServerError('Unexpected response from server');
       }
@@ -93,9 +108,9 @@ export default function Login({ onLogin }) {
               error={Boolean(errors.password)}
               helperText={errors.password}
             />
-            {serverError && (
+            {(serverError || infoMessage) && (
               <Typography color="error" sx={{ mb: 2 }}>
-                {serverError}
+                {serverError || infoMessage}
               </Typography>
             )}
             <Button


### PR DESCRIPTION
## Summary
- Add top-right logout button to clear token and navigate to login
- Redirect to login with message on 401 responses and restore original page after re-authentication
- Display login message when session expired

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68974b791db0832bb6addf3003552a6e