### PR TITLE
Polish admin tables and fix header styling

### DIFF
--- a/src/pages/Breeds.jsx
+++ b/src/pages/Breeds.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import {
   Box, Button, Dialog, DialogTitle, DialogContent, DialogActions,
   Table, TableBody, TableCell, TableHead, TableRow,
+  TableContainer, Paper,
   IconButton, TextField, CircularProgress, Tooltip, Snackbar, Alert,
   MenuItem, Select, InputLabel, FormControl
 } from "@mui/material";
@@ -136,17 +137,18 @@ function Breeds() {
       {loading ? (
         <CircularProgress sx={{ m: 4 }} />
       ) : (
-        <Box sx={{
-          overflowX: "auto",
-          background: "#fff",
-          borderRadius: 3,
-          boxShadow: "0 4px 24px #0001",
-          border: `1.5px solid ${gold}`,
-          mx: "auto"
-        }}>
-          <Table>
-            <TableHead sx={{ bgcolor: gold }}>
-              <TableRow>
+        <TableContainer
+          component={Paper}
+          sx={{
+            borderRadius: 3,
+            boxShadow: "0 4px 24px #0001",
+            border: `1.5px solid ${gold}`,
+            mx: "auto"
+          }}
+        >
+          <Table stickyHeader size="small">
+            <TableHead>
+              <TableRow sx={{ bgcolor: gold }}>
                 <TableCell sx={{ color: "#fff", fontWeight: 700 }}>Name</TableCell>
                 <TableCell sx={{ color: "#fff", fontWeight: 700 }}>Pet Type</TableCell>
                 <TableCell sx={{ color: "#fff", fontWeight: 700 }}>Sort Order</TableCell>
@@ -155,7 +157,7 @@ function Breeds() {
             </TableHead>
             <TableBody>
               {breeds.map(row => (
-                <TableRow key={row.id}>
+                <TableRow hover key={row.id}>
                   <TableCell sx={{ fontWeight: 600, color: brown }}>{row.name}</TableCell>
                   <TableCell>{row.petTypeName}</TableCell>
                   <TableCell>{row.sortOrder}</TableCell>
@@ -176,7 +178,7 @@ function Breeds() {
               )}
             </TableBody>
           </Table>
-        </Box>
+        </TableContainer>
       )}
 
       {/* Add/Edit Dialog */}

--- a/src/pages/Colors.jsx
+++ b/src/pages/Colors.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import {
   Box, Button, Dialog, DialogTitle, DialogContent, DialogActions,
   Table, TableBody, TableCell, TableHead, TableRow,
+  TableContainer, Paper,
   IconButton, TextField, CircularProgress, Tooltip, Snackbar, Alert
 } from "@mui/material";
 import { Edit, Delete, Add, Search } from "@mui/icons-material";
@@ -113,17 +114,18 @@ function Colors() {
       {loading ? (
         <CircularProgress sx={{ m: 4 }} />
       ) : (
-        <Box sx={{
-          overflowX: "auto",
-          background: "#fff",
-          borderRadius: 3,
-          boxShadow: "0 4px 24px #0001",
-          border: `1.5px solid ${gold}`,
-          mx: "auto"
-        }}>
-          <Table>
-            <TableHead sx={{ bgcolor: gold }}>
-              <TableRow>
+        <TableContainer
+          component={Paper}
+          sx={{
+            borderRadius: 3,
+            boxShadow: "0 4px 24px #0001",
+            border: `1.5px solid ${gold}`,
+            mx: "auto"
+          }}
+        >
+          <Table stickyHeader size="small">
+            <TableHead>
+              <TableRow sx={{ bgcolor: gold }}>
                 <TableCell sx={{ color: "#fff", fontWeight: 700 }}>Name</TableCell>
                 <TableCell sx={{ color: "#fff", fontWeight: 700 }}>Sort Order</TableCell>
                 <TableCell align="right" sx={{ color: "#fff", fontWeight: 700 }}>Actions</TableCell>
@@ -131,7 +133,7 @@ function Colors() {
             </TableHead>
             <TableBody>
               {colors.map(row => (
-                <TableRow key={row.id}>
+                <TableRow hover key={row.id}>
                   <TableCell sx={{ fontWeight: 600, color: brown }}>{row.name}</TableCell>
                   <TableCell>{row.sortOrder}</TableCell>
                   <TableCell align="right">
@@ -151,7 +153,7 @@ function Colors() {
               )}
             </TableBody>
           </Table>
-        </Box>
+        </TableContainer>
       )}
 
       {/* Add/Edit Dialog */}

--- a/src/pages/PetFoods.jsx
+++ b/src/pages/PetFoods.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import {
   Box, Button, Dialog, DialogTitle, DialogContent, DialogActions,
   Table, TableBody, TableCell, TableHead, TableRow,
+  TableContainer, Paper,
   IconButton, TextField, CircularProgress, Tooltip, Snackbar, Alert
 } from "@mui/material";
 import { Edit, Delete, Add, Search } from "@mui/icons-material";
@@ -113,17 +114,18 @@ function PetFoods() {
       {loading ? (
         <CircularProgress sx={{ m: 4 }} />
       ) : (
-        <Box sx={{
-          overflowX: "auto",
-          background: "#fff",
-          borderRadius: 3,
-          boxShadow: "0 4px 24px #0001",
-          border: `1.5px solid ${gold}`,
-          mx: "auto"
-        }}>
-          <Table>
-            <TableHead sx={{ bgcolor: gold }}>
-              <TableRow>
+        <TableContainer
+          component={Paper}
+          sx={{
+            borderRadius: 3,
+            boxShadow: "0 4px 24px #0001",
+            border: `1.5px solid ${gold}`,
+            mx: "auto"
+          }}
+        >
+          <Table stickyHeader size="small">
+            <TableHead>
+              <TableRow sx={{ bgcolor: gold }}>
                 <TableCell sx={{ color: "#fff", fontWeight: 700 }}>Name</TableCell>
                 <TableCell sx={{ color: "#fff", fontWeight: 700 }}>Sort Order</TableCell>
                 <TableCell align="right" sx={{ color: "#fff", fontWeight: 700 }}>Actions</TableCell>
@@ -131,7 +133,7 @@ function PetFoods() {
             </TableHead>
             <TableBody>
               {petFoods.map(row => (
-                <TableRow key={row.id}>
+                <TableRow hover key={row.id}>
                   <TableCell sx={{ fontWeight: 600, color: brown }}>{row.name}</TableCell>
                   <TableCell>{row.sortOrder}</TableCell>
                   <TableCell align="right">
@@ -151,7 +153,7 @@ function PetFoods() {
               )}
             </TableBody>
           </Table>
-        </Box>
+        </TableContainer>
       )}
 
       {/* Add/Edit Dialog */}

--- a/src/pages/PetTypes.jsx
+++ b/src/pages/PetTypes.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import {
   Box, Button, Dialog, DialogTitle, DialogContent, DialogActions,
   Table, TableBody, TableCell, TableHead, TableRow,
+  TableContainer, Paper,
   IconButton, TextField, CircularProgress, Tooltip, Avatar, Snackbar, Alert
 } from "@mui/material";
 import { Edit, Delete, Add } from "@mui/icons-material";
@@ -98,18 +99,18 @@ function PetTypes() {
       {loading ? (
         <CircularProgress sx={{ m: 4 }} />
       ) : (
-        <Box sx={{
-          overflowX: "auto",
-          background: "#fff",
-          borderRadius: 3,
-          boxShadow: "0 4px 24px #0001",
-          border: `1.5px solid ${gold}`,
-
-          mx: "auto"
-        }}>
-          <Table>
-            <TableHead sx={{ bgcolor: gold }}>
-              <TableRow>
+        <TableContainer
+          component={Paper}
+          sx={{
+            borderRadius: 3,
+            boxShadow: "0 4px 24px #0001",
+            border: `1.5px solid ${gold}`,
+            mx: "auto"
+          }}
+        >
+          <Table stickyHeader size="small">
+            <TableHead>
+              <TableRow sx={{ bgcolor: gold }}>
                 <TableCell sx={{ color: "#fff", fontWeight: 700 }}>Image</TableCell>
                 <TableCell sx={{ color: "#fff", fontWeight: 700 }}>Name</TableCell>
                 <TableCell sx={{ color: "#fff", fontWeight: 700 }}>SortOrder</TableCell>
@@ -118,7 +119,7 @@ function PetTypes() {
             </TableHead>
             <TableBody>
               {petTypes.map(row => (
-                <TableRow key={row.id}>
+                <TableRow hover key={row.id}>
                   <TableCell>
                     {row.imagePath ? (
                       <Avatar
@@ -152,7 +153,7 @@ function PetTypes() {
               )}
             </TableBody>
           </Table>
-        </Box>
+        </TableContainer>
       )}
 
       {/* Add/Edit Dialog */}

--- a/src/pages/UserTypes.jsx
+++ b/src/pages/UserTypes.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import {
   Box, Button, Dialog, DialogTitle, DialogContent, DialogActions,
   Table, TableBody, TableCell, TableHead, TableRow,
+  TableContainer, Paper,
   IconButton, TextField, CircularProgress, Tooltip, Snackbar, Alert
 } from "@mui/material";
 import { Edit, Delete, Add, Search } from "@mui/icons-material";
@@ -116,17 +117,18 @@ function UserTypes() {
       {loading ? (
         <CircularProgress sx={{ m: 4 }} />
       ) : (
-        <Box sx={{
-          overflowX: "auto",
-          background: "#fff",
-          borderRadius: 3,
-          boxShadow: "0 4px 24px #0001",
-          border: `1.5px solid ${gold}`,
-          mx: "auto"
-        }}>
-          <Table>
-            <TableHead sx={{ bgcolor: gold }}>
-              <TableRow>
+        <TableContainer
+          component={Paper}
+          sx={{
+            borderRadius: 3,
+            boxShadow: "0 4px 24px #0001",
+            border: `1.5px solid ${gold}`,
+            mx: "auto"
+          }}
+        >
+          <Table stickyHeader size="small">
+            <TableHead>
+              <TableRow sx={{ bgcolor: gold }}>
                 <TableCell sx={{ color: "#fff", fontWeight: 700 }}>Image</TableCell>
                 <TableCell sx={{ color: "#fff", fontWeight: 700 }}>Name</TableCell>
                 <TableCell sx={{ color: "#fff", fontWeight: 700 }}>Description</TableCell>
@@ -135,7 +137,7 @@ function UserTypes() {
             </TableHead>
             <TableBody>
               {userTypes.map(row => (
-                <TableRow key={row.id}>
+                <TableRow hover key={row.id}>
                   <TableCell>
                     <img
                       src={row.imagePath}
@@ -162,7 +164,7 @@ function UserTypes() {
               )}
             </TableBody>
           </Table>
-        </Box>
+        </TableContainer>
       )}
 
       {/* Add/Edit Dialog */}


### PR DESCRIPTION
## Summary
- wrap admin tables in `TableContainer`/`Paper` and enable sticky headers
- unify header colors and add row-hover styling for a more professional look

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689755455cb8832b846c273e18aaf1c7